### PR TITLE
Fix build error and add standalone Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,46 @@
+FROM node:20.12-alpine AS base
+
+RUN apk update
+RUN apk add --no-cache libc6-compat
+
+WORKDIR /app
+
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable
+
+FROM base AS deps
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile --prefer-offline
+
+FROM base AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+RUN SECRET_KEY='dummy' pnpm build
+RUN pnpm prune --prod
+
+FROM base AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV APL=sentinel
+# ENV APP_DEBUG='debug'
+
+RUN addgroup --system --gid 1001 nodejs \
+    && adduser --system --uid 1001 nextjs
+
+
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+COPY --from=builder --chown=nextjs:nodejs /app/public ./public
+COPY --from=deps /app/node_modules ./node_modules
+
+USER nextjs
+
+# ENV DEBUG=*
+
+EXPOSE 3000
+
+CMD ["node", "server.js"]

--- a/next.config.js
+++ b/next.config.js
@@ -20,6 +20,7 @@ const nextConfig = {
       "@saleor/apps-shared",
     ],
   },
+  output: "standalone",
   /*
    * Ignore opentelemetry warnings - https://github.com/open-telemetry/opentelemetry-js/issues/4173
    * Remove when https://github.com/open-telemetry/opentelemetry-js/pull/4660 is released

--- a/src/pages/app/checkout.tsx
+++ b/src/pages/app/checkout.tsx
@@ -224,7 +224,7 @@ const CheckoutPage = () => {
                     <Box
                       onClick={() =>
                         navigateToTransaction(
-                          transactionInitializeResult.data.transactionInitialize?.transaction?.id
+                          transactionInitializeResult.data?.transactionInitialize?.transaction?.id
                         )
                       }
                       cursor="pointer"


### PR DESCRIPTION
The Dockerfile.dev runs really slow as it uses next development mode, in a kubernetes cluster environment for testing we use these and we patched a build error and added a "production" dockerfile that runs smoothly. Sometimes the page on the dashboard of the app would crash using the development one, maybe some timeout, the whole pod would restart even sometimes.

Could you check it out @witoszekdev? I think it makes sense for test/QA environments, we don't really test the gateways during some phases and just want dummy payments working there. Our team's version actually bumped app-sdk too so we could use the RedisAPL, which we ended up patching it to use ioredis for Sentinel support and I'm thinking of contributing that here too once the PR on app-sdk gets reviewed. 