### PR TITLE
Include Saleor base URL in externalUrl to pass Saleor request validation

### DIFF
--- a/src/pages/api/webhooks/transaction-cancel-requested.ts
+++ b/src/pages/api/webhooks/transaction-cancel-requested.ts
@@ -65,7 +65,7 @@ export default wrapWithLoggerContext(
         message: "Great success!",
         actions: getTransactionActions("CANCEL_SUCCESS"),
         amount,
-        externalUrl: urlGenerator.getTransactionDetailsUrl(parsedPayload.transaction.id),
+        externalUrl: urlGenerator.getTransactionDetailsUrl(parsedPayload.transaction.id, { includeSaleorBaseUrl: true }),
       };
 
       logger.info("Returning response to Saleor", { response: successResponse });

--- a/src/pages/api/webhooks/transaction-charge-requested.ts
+++ b/src/pages/api/webhooks/transaction-charge-requested.ts
@@ -65,7 +65,7 @@ export default wrapWithLoggerContext(
         message: "Great success!",
         actions: getTransactionActions("CHARGE_SUCCESS"),
         amount,
-        externalUrl: urlGenerator.getTransactionDetailsUrl(parsedPayload.transaction.id),
+        externalUrl: urlGenerator.getTransactionDetailsUrl(parsedPayload.transaction.id, { includeSaleorBaseUrl: true }),
       };
 
       logger.info("Returning response to Saleor", { response: successResponse });

--- a/src/pages/api/webhooks/transaction-initialize-session.ts
+++ b/src/pages/api/webhooks/transaction-initialize-session.ts
@@ -71,7 +71,7 @@ export default wrapWithLoggerContext(
         message: "Great success!",
         actions: getTransactionActions(data.event.type as TransactionEventTypeEnum),
         amount,
-        externalUrl: urlGenerator.getTransactionDetailsUrl(payload.transaction.id),
+        externalUrl: urlGenerator.getTransactionDetailsUrl(payload.transaction.id, { includeSaleorBaseUrl: true }),
       };
 
       logger.info("Returning response to Saleor", { response: successResponse });

--- a/src/pages/api/webhooks/transaction-process-session.ts
+++ b/src/pages/api/webhooks/transaction-process-session.ts
@@ -71,7 +71,7 @@ export default wrapWithLoggerContext(
         message: "Great success!",
         actions: getTransactionActions(data.event.type as TransactionEventTypeEnum),
         amount,
-        externalUrl: urlGenerator.getTransactionDetailsUrl(payload.transaction.id),
+        externalUrl: urlGenerator.getTransactionDetailsUrl(payload.transaction.id, { includeSaleorBaseUrl: true }),
       };
 
       logger.info("Returning response to Saleor", { response: successResponse });

--- a/src/pages/api/webhooks/transaction-refund-requested.ts
+++ b/src/pages/api/webhooks/transaction-refund-requested.ts
@@ -73,7 +73,7 @@ export default wrapWithLoggerContext(
           ? ["REFUND"]
           : [],
         amount,
-        externalUrl: urlGenerator.getTransactionDetailsUrl(parsedPayload.transaction.id),
+        externalUrl: urlGenerator.getTransactionDetailsUrl(parsedPayload.transaction.id, { includeSaleorBaseUrl: true }),
       };
 
       logger.info("Returning response to Saleor", { response: successResponse });


### PR DESCRIPTION
If base URL is not included then Saleor responds with a following error.

_(data excerpt)_
```
{
	"amount": {
		"amount": 2.0
	},
	"createdAt": "2025-08-06T06:56:21.016053+00:00",
	"type": "CHARGE_FAILURE",
	"pspReference": "",
	"message": "Incorrect value (/dashboard/apps/QXBwOjE1/app/app/transactions/VHJhbnNhY3Rpb25JdGVtOmMzZjQ2N2EwLTk5NzYtNGE1OS04MDFjLTRkODFmYThjOTQ2MQ==) for field: externalUrl. Error: Input should be a valid URL, relative URL without a base."
},

```

Validation in Core: https://github.com/saleor/saleor/blob/8eb11da07f09437374cb82daa6f10a80a11a1c90/saleor/webhook/response_schemas/transaction.py#L141-L148.